### PR TITLE
feat: add --summary-only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Run a one-shot snapshot:
 ./agent-top.sh --once
 ```
 
+Run a summary-only snapshot (omit the process tree):
+
+```sh
+./agent-top.sh --once --summary-only
+```
+
 Run a live view:
 
 ```sh

--- a/agent-top.sh
+++ b/agent-top.sh
@@ -4,6 +4,7 @@ set -eu
 INTERVAL_SECONDS=2
 FPS_LABEL=""
 RUN_ONCE=0
+SUMMARY_ONLY=0
 MONITOR_PID=$$
 LIVE_SCREEN_ACTIVE=0
 LOOP_ITERATION=0
@@ -49,12 +50,15 @@ while [ "$#" -gt 0 ]; do
     --once)
       RUN_ONCE=1
       ;;
+    --summary-only)
+      SUMMARY_ONLY=1
+      ;;
     --interval)
       shift
       INTERVAL_SECONDS="${1:-2}"
       ;;
     *)
-      echo "usage: $0 [--once] [--interval seconds]" >&2
+      echo "usage: $0 [--once] [--summary-only] [--interval seconds]" >&2
       exit 1
       ;;
   esac
@@ -1848,6 +1852,12 @@ EOF
   render_panel_lines_wrapped "AgentsCPU: $(render_bar "$AGENT_CPU_PERCENT" "$SUMMARY_BAR_WIDTH" utilization) $(render_metric_text "$AGENT_CPU_PERCENT" utilization "%  ${agent_cpu_cores} cores")"
   render_panel_lines_wrapped "AgentsCPU(norm): $(render_bar "$AGENT_CPU_NORM_PERCENT" "$SUMMARY_BAR_WIDTH" utilization) $(render_metric_text "$AGENT_CPU_NORM_PERCENT" utilization "%")"
   render_panel_lines_wrapped "AgentsMem: $(render_bar "$AGENT_MEM_PERCENT" "$SUMMARY_BAR_WIDTH" utilization) $(render_metric_text "$AGENT_MEM_PERCENT" utilization "%")"
+  if [ "$SUMMARY_ONLY" -eq 1 ]; then
+    if [ "$STYLE_ENABLED" -eq 0 ]; then
+      render_plain_header_line
+    fi
+    return
+  fi
   if [ "$STYLE_ENABLED" -eq 0 ]; then
     render_plain_header_line
   fi

--- a/docs/plans/2026-03-13-summary-only-design.md
+++ b/docs/plans/2026-03-13-summary-only-design.md
@@ -1,0 +1,28 @@
+# Design: --summary-only
+
+## Goal
+Add a `--summary-only` flag to `agent-top.sh` that prints the existing summary panel without the process tree. This reduces `ps` overhead for quick checks and preserves all summary metrics and risk logic.
+
+## Non-Goals
+- No new metrics or risk heuristics.
+- No changes to default output when the flag is not used.
+- No machine-readable output format changes.
+
+## Approach
+- Add a `SUMMARY_ONLY` flag defaulting to `0`, set to `1` when `--summary-only` is passed.
+- Update the usage message to include `--summary-only`.
+- In `render_dashboard`, after the summary lines, skip `render_process_tree` and related panel separators when `SUMMARY_ONLY=1`.
+- Preserve all metric collection and rendering logic. Only the process tree rendering is omitted.
+
+## Behavior Details
+- `--once` and live modes behave the same; both omit the process tree when `--summary-only` is set.
+- In non-styled output, the panel still opens with the same header lines. The summary ends with a single closing border line when `--summary-only` is set.
+- In styled output, the summary renders as usual, then ends without the process header or tree.
+
+## Error Handling
+- Argument parsing rejects unknown flags as today.
+- `--summary-only` does not change validation for `--interval`.
+
+## Testing
+- Extend `tests/test_agent_top.sh` to assert that `--summary-only` output includes summary markers (e.g., `Tasks:`) and excludes the process header (e.g., `PID` and `COMMAND`).
+- Keep existing tests unchanged for default behavior.

--- a/docs/plans/2026-03-13-summary-only.md
+++ b/docs/plans/2026-03-13-summary-only.md
@@ -1,0 +1,156 @@
+# Summary-Only Output Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `--summary-only` flag that renders the summary panel without the process tree.
+
+**Architecture:** Parse a new CLI flag into `SUMMARY_ONLY`, and branch in `render_dashboard` to skip `render_process_tree` and its surrounding borders. Update usage help and document the flag in README. Add tests to assert summary markers remain while process headers are absent.
+
+**Tech Stack:** POSIX `sh`, `awk`, coreutils, existing `tests/test_agent_top.sh`.
+
+---
+
+### Task 1: Add failing summary-only tests
+
+**Files:**
+- Modify: `tests/test_agent_top.sh`
+
+**Step 1: Write the failing test**
+
+Add new outputs near the top:
+
+```sh
+summary_only_output=$("$SCRIPT" --once --summary-only)
+styled_summary_only_output=$(CODEX_TOP_FORCE_STYLE=1 "$SCRIPT" --once --summary-only)
+```
+
+Add assertions after the existing pattern checks:
+
+```sh
+for pattern in "Tasks:" "AgentsCPU" "AgentsMem"; do
+  if ! printf '%s\n' "$summary_only_output" | grep -F "$pattern" >/dev/null 2>&1; then
+    echo "FAIL: --summary-only should keep '$pattern' in the summary" >&2
+    exit 1
+  fi
+done
+
+for pattern in "PID" "COMMAND"; do
+  if printf '%s\n' "$summary_only_output" | grep -F "$pattern" >/dev/null 2>&1; then
+    echo "FAIL: --summary-only should omit the process table header" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$styled_summary_only_output" | grep -F "$pattern" >/dev/null 2>&1; then
+    echo "FAIL: styled --summary-only should omit the process table header" >&2
+    exit 1
+  fi
+done
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```sh
+sh tests/test_agent_top.sh
+```
+
+Expected: FAIL mentioning `--summary-only` (flag unrecognized or missing output).
+
+**Step 3: Commit the failing test**
+
+```sh
+git add tests/test_agent_top.sh
+git commit -m "test: cover --summary-only output"
+```
+
+---
+
+### Task 2: Implement summary-only rendering
+
+**Files:**
+- Modify: `agent-top.sh`
+
+**Step 1: Implement minimal code**
+
+Add flag parsing and state:
+
+```sh
+SUMMARY_ONLY=0
+```
+
+Update the CLI parser:
+
+```sh
+    --summary-only)
+      SUMMARY_ONLY=1
+      ;;
+```
+
+Update usage to include `--summary-only`.
+
+In `render_dashboard`, gate the process tree:
+
+```sh
+  if [ "$STYLE_ENABLED" -eq 0 ]; then
+    render_plain_header_line
+  fi
+  if [ "$SUMMARY_ONLY" -eq 0 ]; then
+    render_process_tree
+    if [ "$STYLE_ENABLED" -eq 0 ]; then
+      render_plain_header_line
+    fi
+  elif [ "$STYLE_ENABLED" -eq 0 ]; then
+    render_plain_header_line
+  fi
+```
+
+**Step 2: Run tests**
+
+Run:
+
+```sh
+sh tests/test_agent_top.sh
+```
+
+Expected: PASS.
+
+**Step 3: Commit**
+
+```sh
+git add agent-top.sh
+git commit -m "feat: add --summary-only flag"
+```
+
+---
+
+### Task 3: Document the new flag
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Update usage docs**
+
+Add a short example:
+
+```sh
+./agent-top.sh --once --summary-only
+```
+
+Mention that it omits the process tree.
+
+**Step 2: Run tests (smoke check)**
+
+Run:
+
+```sh
+sh tests/test_agent_top.sh
+```
+
+Expected: PASS.
+
+**Step 3: Commit**
+
+```sh
+git add README.md
+git commit -m "docs: document --summary-only"
+```

--- a/tests/test_agent_top.sh
+++ b/tests/test_agent_top.sh
@@ -10,7 +10,9 @@ if [ ! -x "$SCRIPT" ]; then
 fi
 
 output=$("$SCRIPT" --once)
+summary_only_output=$("$SCRIPT" --once --summary-only)
 styled_output=$(CODEX_TOP_FORCE_STYLE=1 "$SCRIPT" --once)
+styled_summary_only_output=$(CODEX_TOP_FORCE_STYLE=1 "$SCRIPT" --once --summary-only)
 plain_diff_output=$(CODEX_TOP_TEST_MODE=diff "$SCRIPT" --once)
 styled_diff_output=$(CODEX_TOP_FORCE_STYLE=1 CODEX_TOP_TEST_MODE=diff "$SCRIPT" --once)
 styled_risk_warn_output=$(CODEX_TOP_FORCE_STYLE=1 CODEX_TOP_TEST_MODE=risk_warn "$SCRIPT" --once)
@@ -98,6 +100,24 @@ fi
 for pattern in "TERMUX SYSTEM SNAPSHOT" "Tasks:" "Mem:" "Swap:" "CLAUDE" "CODEX" "AgentsMem:" "PID" "%MEM" "LOCATION"; do
   if ! printf '%s\n' "$output" | grep -F "$pattern" >/dev/null 2>&1; then
     echo "FAIL: missing pattern '$pattern'" >&2
+    exit 1
+  fi
+done
+
+for pattern in "Tasks:" "AgentsCPU" "AgentsMem"; do
+  if ! printf '%s\n' "$summary_only_output" | grep -F "$pattern" >/dev/null 2>&1; then
+    echo "FAIL: --summary-only should keep '$pattern' in the summary" >&2
+    exit 1
+  fi
+done
+
+for pattern in "PID" "COMMAND"; do
+  if printf '%s\n' "$summary_only_output" | grep -F "$pattern" >/dev/null 2>&1; then
+    echo "FAIL: --summary-only should omit the process table header" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$styled_summary_only_output" | grep -F "$pattern" >/dev/null 2>&1; then
+    echo "FAIL: styled --summary-only should omit the process table header" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary
- add a --summary-only flag to render only the summary panel
- add tests covering summary-only output
- document summary-only usage

## Test Plan
- [x] sh tests/test_agent_top.sh
- [x] ./agent-top.sh --once --summary-only
